### PR TITLE
Omnicia Audit Fix: NFT-03M

### DIFF
--- a/contracts/NFTBoostVault.sol
+++ b/contracts/NFTBoostVault.sol
@@ -28,7 +28,7 @@ import {
     NBV_AlreadyUnlocked,
     NBV_NotAirdrop,
     NBV_NoRegistration,
-    NBV_NewDelegatee
+    NBV_WrongDelegatee
 } from "./errors/Governance.sol";
 
 /**
@@ -151,6 +151,9 @@ contract NFTBoostVault is INFTBoostVault, BaseVotingVault {
         if (registration.delegatee == address(0)) {
             _registerAndDelegate(user, amount, 0, address(0), delegatee);
         } else {
+            // if user supplies new delegatee address revert
+            if (delegatee != registration.delegatee) revert NBV_WrongDelegatee(delegatee, registration.delegatee);
+
             // get this contract's balance
             Storage.Uint256 storage balance = _balance();
             // update contract balance
@@ -158,8 +161,7 @@ contract NFTBoostVault is INFTBoostVault, BaseVotingVault {
 
             // update registration amount
             registration.amount += amount;
-            // if user supplies new delegatee address revert
-            if (delegatee != registration.delegatee) revert NBV_NewDelegatee(delegatee, registration.delegatee);
+
             // sync current delegatee's voting power
             _syncVotingPower(user, registration);
         }

--- a/contracts/errors/Governance.sol
+++ b/contracts/errors/Governance.sol
@@ -100,7 +100,7 @@ error NBV_NotAirdrop();
  * @notice If a user already has a registration, they cannot change their
  *         delegatee when claiming subsequent airdrops.
  */
-error NBV_NewDelegatee(address newDelegate, address currentDelegate);
+error NBV_WrongDelegatee(address newDelegate, address currentDelegate);
 
 // =================================== FROZEN LOCKING VAULT =====================================
 /// @notice All errors prefixed with FLV_, to separate from other contracts in governance.


### PR DESCRIPTION
There is an error with the `airdropReceive` function in the NFTBoostVault where if a user calls the function twice with 2 different `delegatee` addresses the second call will not update the users registration with the new delegates address. To fix this issue a check is put in place to check that if a user already have a `delegatee` in their Registration, they cannot update it when receiving an airdrop. The supplied `delegatee` address must be the same as the current address in the users registration.

In the same function, the call the `_syncVotingPower` is also updated to reflect the correct user whose voting power is being updated. Previously it was the caller not the registration owner.