### PR TITLE
Omnicia Audit Fix: ATY-02M

### DIFF
--- a/contracts/ArcadeTreasury.sol
+++ b/contracts/ArcadeTreasury.sol
@@ -275,6 +275,13 @@ contract ArcadeTreasury is IArcadeTreasury, AccessControl, ReentrancyGuard {
             revert T_ThresholdsNotAscending();
         }
 
+        // if gscAllowance is greater than new small threshold, set it to the new small threshold
+        if (thresholds.small < gscAllowance[token]) {
+            gscAllowance[token] = thresholds.small;
+
+            emit GSCAllowanceUpdated(token, thresholds.small);
+        }
+
         // Overwrite the spend limits for specified token
         spendThresholds[token] = thresholds;
 
@@ -301,12 +308,6 @@ contract ArcadeTreasury is IArcadeTreasury, AccessControl, ReentrancyGuard {
         }
 
         uint256 spendLimit = spendThresholds[token].small;
-        if (gscAllowance[token] > spendLimit) {
-            gscAllowance[token] = spendLimit;
-
-            emit GSCAllowanceUpdated(token, spendLimit);
-        }
-
         // new limit cannot be more than the small threshold
         if (newAllowance > spendLimit) {
             revert T_InvalidAllowance(newAllowance, spendLimit);


### PR DESCRIPTION
Setting an allowance before reducing the `small threshold` of the `token` allows the GSC spending threshold to exceed a current `small threshold` value.

Added logic to update GSC allowance to eq. `small threshold` in the event that `small threshold` is less than GSC allowance, before a new allowance is set by the admin.

Added corresponding test.

Run `yarn test`.