### PR TITLE
Omnicia Audit Fix: NFT-01M

### DIFF
--- a/contracts/NFTBoostVault.sol
+++ b/contracts/NFTBoostVault.sol
@@ -304,12 +304,17 @@ contract NFTBoostVault is INFTBoostVault, BaseVotingVault {
 
         NFTBoostVaultStorage.Registration storage registration = _getRegistrations()[msg.sender];
 
+        // If the registration does not have a delegatee, revert because the Registration
+        // is not initialized
+        if (registration.delegatee == address(0)) revert NBV_NoRegistration();
+
+        // if the user already has an ERC1155 registered, withdraw it
         if (registration.tokenAddress != address(0) && registration.tokenId != 0) {
             // withdraw the current ERC1155 from the registration
             _withdrawNft();
         }
 
-        // set the new ERC1155 values in the registration
+        // set the new ERC1155 values in the registration and lock the new ERC1155
         registration.tokenAddress = newTokenAddress;
         registration.tokenId = newTokenId;
 

--- a/test/NftBoostVault.ts
+++ b/test/NftBoostVault.ts
@@ -1232,6 +1232,24 @@ describe("Governance Operations with NFT Boost Voting Vault", async () => {
             await expect(tx).to.be.revertedWith("NBV_DoesNotOwn");
         });
 
+        it("Reverts if user calls updateNft() without an existing registration", async () => {
+            const { signers, nftBoostVault, reputationNft, mintNfts, setMultipliers } = ctxGovernance;
+
+            // mint users some ERC1155 nfts
+            await mintNfts();
+
+            await setMultipliers();
+
+            // confirm that signers[1] owns reputationNft id 1
+            const userBal = await reputationNft.balanceOf(signers[1].address, 1);
+            expect(userBal).to.be.eq(1);
+
+            // signers[1] tries to add NFT without prior registration
+            await expect(nftBoostVault.connect(signers[1]).updateNft(1, reputationNft.address)).to.be.revertedWith(
+                "NBV_NoRegistration()",
+            );
+        });
+
         it("Returns ZERO when _getWithdrawableAmount() is triggered for a non-registration", async () => {
             const { arcdToken } = ctxToken;
             const { signers, nftBoostVault, reputationNft, mintNfts, setMultipliers } = ctxGovernance;


### PR DESCRIPTION
Add a check to `updateNft` function in the NFTBoostVault to ensure that the registration exists. Without this check, users can deposit an NFT into an empty registration. Test added to check registration prior to updating NFT.