### PR TITLE
Omnicia Audit Fix: BVV-01M

### DIFF
--- a/contracts/BaseVotingVault.sol
+++ b/contracts/BaseVotingVault.sol
@@ -11,7 +11,7 @@ import "./libraries/HashedStorageReentrancyBlock.sol";
 
 import "./interfaces/IBaseVotingVault.sol";
 
-import { BVV_NotManager, BVV_NotTimelock, BVV_ZeroAddress } from "./errors/Governance.sol";
+import { BVV_NotManager, BVV_NotTimelock, BVV_ZeroAddress, BVV_UpperLimitBlock } from "./errors/Governance.sol";
 
 /**
  * @title BaseVotingVault
@@ -51,6 +51,7 @@ abstract contract BaseVotingVault is HashedStorageReentrancyBlock, IBaseVotingVa
      */
     constructor(IERC20 _token, uint256 _staleBlockLag) {
         if (address(_token) == address(0)) revert BVV_ZeroAddress("token");
+        if (_staleBlockLag >= block.number) revert BVV_UpperLimitBlock(_staleBlockLag);
 
         token = _token;
         staleBlockLag = _staleBlockLag;

--- a/contracts/errors/Governance.sol
+++ b/contracts/errors/Governance.sol
@@ -193,3 +193,11 @@ error BVV_NotTimelock();
  *                                   address was provided.
  */
 error BVV_ZeroAddress(string addressType);
+
+/**
+ * @notice The provided stale block number is too high.
+ *
+ * @param staleBlock                The block number in the past, provided at deployment
+ *                                  before which a user's history is pruned.
+ */
+error BVV_UpperLimitBlock(uint256 staleBlock);

--- a/test/NftBoostVault.ts
+++ b/test/NftBoostVault.ts
@@ -43,6 +43,10 @@ describe("Governance Operations with NFT Boost Voting Vault", async () => {
 
         const staleBlockNum = 10;
 
+        // get current block number
+        const blockNumber = await ethers.provider.getBlockNumber();
+        const staleBlockNum2 = blockNumber + 10; // adding ten to exceed current block
+
         await expect(
             deploy("NFTBoostVault", signers[0], [
                 ethers.constants.AddressZero,
@@ -69,6 +73,15 @@ describe("Governance Operations with NFT Boost Voting Vault", async () => {
                 ethers.constants.AddressZero,
             ]),
         ).to.be.revertedWith(`NBV_ZeroAddress("manager")`);
+
+        await expect(
+            deploy("NFTBoostVault", signers[0], [
+                signers[0].address,
+                staleBlockNum2, // make the staleBlockLag equal to current block number
+                signers[1].address,
+                signers[1].address,
+            ]),
+        ).to.be.revertedWith(`BVV_UpperLimitBlock(${staleBlockNum2}`);
     });
 
     describe("Governance flow with NFT boost vault", async () => {

--- a/test/utils/governanceFixture.ts
+++ b/test/utils/governanceFixture.ts
@@ -56,11 +56,12 @@ export const governanceFixture = (arcdToken: ArcadeToken): (() => Promise<TestCo
         let votingVaults: string[] = [];
         let arcadeGSCVaults: string[] = [];
 
-        const staleBlock = await ethers.provider.getBlock("latest");
-        const staleBlockNum = staleBlock.number;
+        const blockNumber = await ethers.provider.getBlockNumber();
+        // staleBlockNum has to be a number in the past, lower than the current block number.
+        // upon deployment, update staleBlockNum to be relevant in the realm of mainnet
+        const staleBlockNum = blockNumber - 5;
 
         // ================================= CORE VOTING VAULTS =================================
-
         // deploy locking vault
         const lockingVotingVault = <LockingVault>(
             await deploy("LockingVault", signers[0], [arcdToken.address, staleBlockNum])


### PR DESCRIPTION
Added upper limit check to `staleBlockLag`, `revert` statement and test.

Did not specify a `staleBlockLag` lower limit because as the "current" block number keeps growing, whatever lower limit is set becomes inadequate.

Run `yarn test`.