### PR TITLE
Omnicia Audit Fix: ARC-01C

### DIFF
--- a/contracts/ARCDVestingVault.sol
+++ b/contracts/ARCDVestingVault.sol
@@ -83,8 +83,8 @@ contract ARCDVestingVault is IARCDVestingVault, HashedStorageReentrancyBlock, Ba
      * @param cliffAmount                The amount of tokens that will be unlocked at the cliff.
      * @param startTime                  Optionally set a start time in the future. If set to zero
      *                                   then the start time will be made the block tx is in.
-     * @param expiration                 Timestamp when the grant ends (all tokens count as unlocked).
-     * @param cliff                      Timestamp when the cliff ends. No tokens are unlocked until
+     * @param expiration                 Timestamp when the grant ends - all tokens are unlocked and withdrawable.
+     * @param cliff                      Timestamp when the cliff ends. cliffAmount tokens are withdrawable when
      *                                   this timestamp is reached.
      * @param delegatee                  The address to delegate the voting power to
      */


### PR DESCRIPTION
Improved the issue referenced Natspec for improvement of verbiage and clarity.

Re. prefixing variables that are only accessible within a function with an underscore: 
We elect not to make this change as it is a deviation from our wider codebase conventions.  We generally use underscore prefixes for variable names that shadow other variables or functions within the contract.