### PR TITLE
Omnicia Audit Fix: ARC-05C

### DIFF
--- a/contracts/ARCDVestingVault.sol
+++ b/contracts/ARCDVestingVault.sol
@@ -106,7 +106,7 @@ contract ARCDVestingVault is IARCDVestingVault, HashedStorageReentrancyBlock, Ba
             startTime = uint128(block.number);
         }
         // grant schedule check
-        if (cliff >= expiration || startTime >= expiration || cliff < startTime) revert AVV_InvalidSchedule();
+        if (cliff >= expiration || cliff < startTime) revert AVV_InvalidSchedule();
 
         // cliff check
         if (cliffAmount >= amount) revert AVV_InvalidCliffAmount();


### PR DESCRIPTION
Removed `startTime >= expiration` from `if (cliff >= expiration || startTime >= expiration || cliff < startTime) revert AVV_InvalidSchedule();` because `cliff >= expiration || cliff < startTime` guarantees that the `startTime >= expiration` check will revert.

Run `yarn test`.