### PR TITLE
Omnicia Audit Fix: ARC-06C 

### DIFF
--- a/contracts/ARCDVestingVault.sol
+++ b/contracts/ARCDVestingVault.sol
@@ -171,7 +171,7 @@ contract ARCDVestingVault is IARCDVestingVault, HashedStorageReentrancyBlock, Ba
         // transfer the remaining tokens to the vesting manager
         uint256 remaining = grant.allocation - grant.withdrawn;
         grant.withdrawn += uint128(remaining);
-        token.safeTransfer(_manager().data, remaining);
+        token.safeTransfer(msg.sender, remaining);
 
         // update the delegatee's voting power
         _syncVotingPower(who, grant);


### PR DESCRIPTION
Replaced `_manager.data()` with `msg.sender` since the `onlyManager` modifier will ensure that the caller is the manager.
This avoids the need to load storage.

Run `yarn test`.