### PR TITLE
Omnicia Audit Fix: BDR-01C

### DIFF
--- a/contracts/nft/BadgeDescriptor.sol
+++ b/contracts/nft/BadgeDescriptor.sol
@@ -17,7 +17,7 @@ import "../interfaces/IBadgeDescriptor.sol";
 contract BadgeDescriptor is IBadgeDescriptor, Ownable {
     using Strings for uint256;
 
-    event SetBaseURI(address indexed caller, string indexed baseURI);
+    event SetBaseURI(address indexed caller, string baseURI);
 
     // ============================================ STATE ==============================================
 


### PR DESCRIPTION
Remove 'indexed' keyword from the `SetBaseURI` event. It is not needed.