### PR TITLE
Omnicia Audit Fix: AMR-01C

### DIFF
--- a/contracts/libraries/ArcadeMerkleRewards.sol
+++ b/contracts/libraries/ArcadeMerkleRewards.sol
@@ -21,7 +21,7 @@ import { AA_ClaimingExpired, AA_AlreadyClaimed, AA_NonParticipant, AA_ZeroAddres
  * Arcade Governance. When claiming, the user can delegate voting power to themselves or another
  * account.
  */
-contract ArcadeMerkleRewards {
+abstract contract ArcadeMerkleRewards {
     // ============================================ STATE ==============================================
 
     // =================== Immutable references =====================


### PR DESCRIPTION
The inheriting contracts of `ArcadeMerkleRewards` have the ability to update the `rewardsRoot` and `votingVault` variable values that are set in the `ArcadeMerkleRewards constructor`.

Updated `ArcadeMerkleRewards.sol` to be `abstract`.

Run `yarn test`.