### PR TITLE
Omnicia Audit Fix: ARC-09C 

### DIFF
--- a/contracts/ARCDVestingVault.sol
+++ b/contracts/ARCDVestingVault.sol
@@ -186,8 +186,6 @@ contract ARCDVestingVault is IARCDVestingVault, HashedStorageReentrancyBlock, Ba
         grant.cliff = 0;
         grant.latestVotingPower = 0;
         grant.delegatee = address(0);
-
-        // delete _grants()[who];
     }
 
     /**


### PR DESCRIPTION
Removed the repeated dynamic calculation of storage offset in `revokeGrant()` and  `addGrantAndDelegate()`.
Replaced it with a local storage variable.

Run `yarn test`.