### PR TITLE
Omnicia Audit Fix: NFT-05C

### DIFF
--- a/contracts/NFTBoostVault.sol
+++ b/contracts/NFTBoostVault.sol
@@ -448,7 +448,7 @@ contract NFTBoostVault is INFTBoostVault, BaseVotingVault {
      * @notice A helper function to register a user and delegate their voting power. This function is called
      *         when a user does not have a Registration created yet.
      *
-     * @param user                         The address of the user to register.
+     * @param user                          The address of the user to register.
      * @param _amount                       Amount of tokens to be locked.
      * @param _tokenId                      The id of the ERC1155 NFT.
      * @param _tokenAddress                 The address of the ERC1155 token.


### PR DESCRIPTION
When initializing the registration in the NFTBoostVault `_registerAndDelegate` function, initialized each struct member individually to enhance the readability of the contract and which struct parameters were being set. This is similar to the change made in ARC-09C.