### PR TITLE
Omnicia Audit Fix: ARC-01S Addendum

### DIFF
--- a/contracts/ARCDVestingVault.sol
+++ b/contracts/ARCDVestingVault.sol
@@ -201,7 +201,7 @@ contract ARCDVestingVault is IARCDVestingVault, HashedStorageReentrancyBlock, Ba
         Storage.Uint256 storage unassigned = _unassigned();
         // update unassigned value
         unassigned.data += amount;
-        token.safeTransferFrom(msg.sender, address(this), amount);
+        token.transferFrom(msg.sender, address(this), amount);
     }
 
     /**


### PR DESCRIPTION
Removed the use of `SafeERC20` `safeTransferFrom` where the transfer is to `address(this)`.  
Because we designed the contract, and we know it is safe. So we can use the simpler `transferFrom` to save some gas.  

Run `yarn test`.

This is a revert to an update made in this [PR](https://github.com/arcadexyz/governance/pull/52).