### PR TITLE
Omnicia Audit Fix: NFT-02S Addendum 

### DIFF
--- a/contracts/NFTBoostVault.sol
+++ b/contracts/NFTBoostVault.sol
@@ -654,7 +654,7 @@ contract NFTBoostVault is INFTBoostVault, BaseVotingVault {
         uint128 tokenId,
         uint128 nftAmount
     ) internal {
-        token.safeTransferFrom(from, address(this), amount);
+        token.transferFrom(from, address(this), amount);
 
         if (tokenAddress != address(0) && tokenId != 0) {
             _lockNft(from, tokenAddress, tokenId, nftAmount);


### PR DESCRIPTION
Removed the use of `SafeERC20` `safeTransferFrom` where the transfer recipient is `address(this)`, because we designed the contract and we know it is safe. We can use the simpler `transferFrom` here to save some gas.

Run `yarn test`.

This is a revert to an update made in this [PR](https://github.com/arcadexyz/governance/pull/63).