### PR TITLE
Omnicia Audit Fix: NFT-04C

### DIFF
--- a/contracts/NFTBoostVault.sol
+++ b/contracts/NFTBoostVault.sol
@@ -247,7 +247,11 @@ contract NFTBoostVault is INFTBoostVault, BaseVotingVault {
             if (registration.tokenAddress != address(0) && registration.tokenId != 0) {
                 _withdrawNft();
             }
-            delete _getRegistrations()[msg.sender];
+            // delete registration. tokenId and token address already set to 0 in _withdrawNft()
+            registration.amount = 0;
+            registration.latestVotingPower = 0;
+            registration.withdrawn = 0;
+            registration.delegatee = address(0);
         }
 
         // transfer the token amount to the user


### PR DESCRIPTION
Optimize the `withdraw` function in the NFTBoostVault to use the `registration` loaded at the top of the function for cases where the registration is to be deleted when there are no more tokens locked in the vault for a particular user. Instead of re-loading the registration to delete it. Use the existing struct in memory to set values to zero. Note, tokenId and tokenAddress are already set to zero in the `_withdrawNft` function which is called every time a user withdraws any remaining ERC20s which they had in the vault.