### PR TITLE
Snapshot BalanceQuery Contract and Deployment Script

### DIFF
--- a/contracts/snapshot/BalanceQuery.sol
+++ b/contracts/snapshot/BalanceQuery.sol
@@ -13,12 +13,13 @@ contract BalanceQuery is Authorizable, IVotingVaultView {
     IVotingVaultView[] public vaults;
 
     /**
-     * @notice Constructs this contract and stores needed data
+     * @notice Constructs this contract and stores needed data. Sets the deployer as the owner
+     *         and authorizes the _vaultManager to be able to add/remove vaults.
      *
-     * @param _owner                The contract owner authorized to remove vaults
+     * @param _vaultManager         User authorized to add/remove vaults
      * @param votingVaults          An array of the vaults to query balances from
      */
-    constructor(address _owner, address[] memory votingVaults) {
+    constructor(address _vaultManager, address[] memory votingVaults) {
         // create a new array of voting vaults
         vaults = new IVotingVaultView[](votingVaults.length);
         // populate array with each vault passed into constructor
@@ -26,8 +27,8 @@ contract BalanceQuery is Authorizable, IVotingVaultView {
             vaults[i] = IVotingVaultView(votingVaults[i]);
         }
 
-        // authorize the owner address to be able to add/remove vaults
-        _authorize(_owner);
+        // authorize the _vaultManager to be able to add/remove vaults
+        _authorize(_vaultManager);
     }
 
     /**

--- a/scripts/deploy/balance-query.ts
+++ b/scripts/deploy/balance-query.ts
@@ -9,7 +9,7 @@ export interface SnapshotDeployedResources {
 
 /**
  * To run this script use:
- * `FORK_MAINNET=true npx hardhat run scripts/deploy/balance-query.ts --network <networkName>`
+ * `npx hardhat run scripts/deploy/balance-query.ts --network <networkName>`
  */
 
 export async function main(): Promise<SnapshotDeployedResources> {
@@ -31,12 +31,26 @@ export async function main(): Promise<SnapshotDeployedResources> {
             IMM_VESTINGVAULT_ADD,
             ARCADE_GSCVAULT_ADD,
         ])
-    ); // owner, nftboostvault, vestingVault, immutablevestingvault, gscvault addresses
+    );
     await balanceQuery.deployed();
     const balanceQueryAddress = balanceQuery.address;
 
     console.log("BalanceQuery deployed to:", balanceQueryAddress);
     console.log(SUBSECTION_SEPARATOR);
+
+    // timeout for 3 seconds to wait for etherscan to index the contract
+    await new Promise(r => setTimeout(r, 3000));
+
+    console.log("Verifying BalanceQuery contract...");
+    await hre.run("verify:verify", {
+        address: balanceQueryAddress,
+        constructorArguments: [
+            OWNER_ADD,
+            [NFTBOOSTVAULT_ADD, ARCD_VESTINGVAULT_ADD, IMM_VESTINGVAULT_ADD, ARCADE_GSCVAULT_ADD],
+        ],
+    });
+
+    console.log(SECTION_SEPARATOR);
 
     return {
         balanceQuery,


### PR DESCRIPTION
This PR includes the `BalanceQuery` contract which computes the voting power of ARCD token holders who have tokens staked in governance voting vaults for use in Snapshot.

Deploy `BalanceQuery` by running:
`FORK_MAINNET=true npx hardhat run scripts/deploy/balance-query.ts --network <networkName>`

And add the deployed `BalanceQuery` contract address in Snapshot as shown encircled in the screenshot.  To get to that screen, go to `Settings` > `Strategies `

![Screenshot 2023-08-28 at 6 54 31 PM](https://github.com/arcadexyz/governance/assets/42501101/5693b5a7-aebc-4c02-9480-e66662fe1ab1)


