### PR TITLE
Update token distributor allocations

### DIFF
--- a/contracts/token/ArcadeTokenDistributor.sol
+++ b/contracts/token/ArcadeTokenDistributor.sol
@@ -27,8 +27,8 @@ contract ArcadeTokenDistributor is Ownable {
     /// @notice The Arcade Token contract to be used in token distribution.
     IArcadeToken public arcadeToken;
 
-    /// @notice 25.1% of initial distribution is for the governance treasury
-    uint256 public constant governanceTreasuryAmount = 25_100_000 ether;
+    /// @notice 25.499484% of initial distribution is for the governance treasury
+    uint256 public constant governanceTreasuryAmount = 25_499_484 ether;
     /// @notice A flag to indicate if the governance treasury has already been transferred to
     bool public governanceTreasurySent;
 
@@ -52,13 +52,13 @@ contract ArcadeTokenDistributor is Ownable {
     /// @notice A flag to indicate if the community airdrop contract has already been transferred to
     bool public communityAirdropSent;
 
-    /// @notice 15.61262% of initial distribution is for the Arcade team vesting
-    uint256 public constant vestingTeamAmount = 15_612_620 ether;
+    /// @notice 15.54647% of initial distribution is for the Arcade team vesting
+    uint256 public constant vestingTeamAmount = 15_546_470 ether;
     /// @notice A flag to indicate if the Arcade team vesting have already been transferred to
     bool public vestingTeamSent;
 
-    /// @notice 33.206096% of initial distribution is for Arcade's launch partner vesting
-    uint256 public constant vestingPartnerAmount = 33_206_096 ether;
+    /// @notice 33.872762% of initial distribution is for Arcade's launch partner vesting
+    uint256 public constant vestingPartnerAmount = 32_872_762 ether;
     /// @notice A flag to indicate if Arcade's launch partner vesting has already been transferred to
     bool public vestingPartnerSent;
 

--- a/test/Treasury.ts
+++ b/test/Treasury.ts
@@ -14,7 +14,7 @@ describe("Arcade Treasury", async () => {
     let ctxGovernance: TestContextGovernance;
     let fixtureToken: () => Promise<TestContextToken>;
     let fixtureGov: () => Promise<TestContextGovernance>;
-    const treasuryAmount = ethers.utils.parseEther("25100000");
+    const treasuryAmount = ethers.utils.parseEther("25499484");
 
     beforeEach(async function () {
         fixtureToken = await tokenFixture();

--- a/test/token/Token.ts
+++ b/test/token/Token.ts
@@ -282,7 +282,7 @@ describe("ArcadeToken", function () {
 
             await expect(await arcdDst.connect(deployer).toGovernanceTreasury(govTreasury.address))
                 .to.emit(arcdDst, "Distribute")
-                .withArgs(arcdToken.address, govTreasury.address, ethers.utils.parseEther("25100000"));
+                .withArgs(arcdToken.address, govTreasury.address, ethers.utils.parseEther("25499484"));
             await expect(await arcdDst.connect(deployer).toFoundationTreasury(foundationTreasury.address))
                 .to.emit(arcdDst, "Distribute")
                 .withArgs(arcdToken.address, foundationTreasury.address, ethers.utils.parseEther("10000000"));
@@ -297,10 +297,10 @@ describe("ArcadeToken", function () {
                 .withArgs(arcdToken.address, arcdAirdrop.address, ethers.utils.parseEther("6000000"));
             await expect(await arcdDst.connect(deployer).toPartnerVesting(vestingPartner.address))
                 .to.emit(arcdDst, "Distribute")
-                .withArgs(arcdToken.address, vestingPartner.address, ethers.utils.parseEther("33206096"));
+                .withArgs(arcdToken.address, vestingPartner.address, ethers.utils.parseEther("32872762"));
             await expect(await arcdDst.connect(deployer).toTeamVesting(vestingTeamMultisig.address))
                 .to.emit(arcdDst, "Distribute")
-                .withArgs(arcdToken.address, vestingTeamMultisig.address, ethers.utils.parseEther("15612620"));
+                .withArgs(arcdToken.address, vestingTeamMultisig.address, ethers.utils.parseEther("15546470"));
 
             expect(await arcdDst.governanceTreasurySent()).to.be.true;
             expect(await arcdDst.foundationTreasurySent()).to.be.true;
@@ -310,16 +310,16 @@ describe("ArcadeToken", function () {
             expect(await arcdDst.vestingTeamSent()).to.be.true;
             expect(await arcdDst.vestingPartnerSent()).to.be.true;
 
-            expect(await arcdToken.balanceOf(govTreasury.address)).to.equal(ethers.utils.parseEther("25100000"));
+            expect(await arcdToken.balanceOf(govTreasury.address)).to.equal(ethers.utils.parseEther("25499484"));
             expect(await arcdToken.balanceOf(foundationTreasury.address)).to.equal(ethers.utils.parseEther("10000000"));
             expect(await arcdToken.balanceOf(devPartner.address)).to.equal(ethers.utils.parseEther("1081284"));
             expect(await arcdToken.balanceOf(communityRewardsPool.address)).to.equal(
                 ethers.utils.parseEther("9000000"),
             );
             expect(await arcdToken.balanceOf(arcdAirdrop.address)).to.equal(ethers.utils.parseEther("6000000"));
-            expect(await arcdToken.balanceOf(vestingPartner.address)).to.equal(ethers.utils.parseEther("33206096"));
+            expect(await arcdToken.balanceOf(vestingPartner.address)).to.equal(ethers.utils.parseEther("32872762"));
             expect(await arcdToken.balanceOf(vestingTeamMultisig.address)).to.equal(
-                ethers.utils.parseEther("15612620"),
+                ethers.utils.parseEther("15546470"),
             );
 
             expect(await arcdToken.balanceOf(arcdDst.address)).to.equal(0);


### PR DESCRIPTION
This PR makes changes to the ArcadeTokenDistributor contract to reflect the latest distribution amounts. All amounts total 100 million tokens which is the initial balance of the distributor contract after ARCD token deployment.