### PR TITLE
[C4-L01]: Cannot claim airdrop if merkle root is not initialized

### DIFF
--- a/contracts/errors/Airdrop.sol
+++ b/contracts/errors/Airdrop.sol
@@ -45,4 +45,4 @@ error AA_ZeroAddress(string addressType);
 /**
  * @notice Thrown when the merkle root is set to bytes32(0).
  */
-error AA_InvalidMerkleRoot();
+error AA_NotInitialized();

--- a/contracts/libraries/ArcadeMerkleRewards.sol
+++ b/contracts/libraries/ArcadeMerkleRewards.sol
@@ -12,7 +12,7 @@ import {
     AA_AlreadyClaimed,
     AA_NonParticipant,
     AA_ZeroAddress,
-    AA_InvalidMerkleRoot
+    AA_NotInitialized
 } from "../errors/Airdrop.sol";
 
 /**
@@ -85,7 +85,7 @@ abstract contract ArcadeMerkleRewards {
      * @param merkleProof            The merkle proof showing the user is in the merkle tree
      */
     function claimAndDelegate(address delegate, uint128 totalGrant, bytes32[] calldata merkleProof) external {
-        if (rewardsRoot == bytes32(0)) revert AA_InvalidMerkleRoot();
+        if (rewardsRoot == bytes32(0)) revert AA_NotInitialized();
         // must be before the expiration time
         if (block.timestamp > expiration) revert AA_ClaimingExpired();
         // validate the withdraw

--- a/test/token/Token.ts
+++ b/test/token/Token.ts
@@ -816,7 +816,7 @@ describe("ArcadeToken", function () {
                     recipients[0].value, // total claimable amount
                     proofDeployer, // invalid merkle proof
                 ),
-            ).to.be.revertedWith("AA_InvalidMerkleRoot()");
+            ).to.be.revertedWith("AA_NotInitialized()");
         });
 
         it("owner reclaims all unclaimed tokens", async function () {


### PR DESCRIPTION
Add `bytes32(0)` check to the airdrop claim function. Revert if the merkle root is not initialized