### PR TITLE
Add low custom quorum for whitelisting collateral in the lending protocol

### DIFF
--- a/scripts/deploy/config/custom-quorum-params.ts
+++ b/scripts/deploy/config/custom-quorum-params.ts
@@ -5,13 +5,16 @@ import { ethers } from "hardhat";
 ///////////////////////////////
 
 // ArcadeCoreVoting
-export const CV_MEDIUM_QUORUM = ethers.utils.parseEther("3000000");
-export const CV_HIGH_QUORUM = ethers.utils.parseEther("6000000");
-export const CV_VERY_HIGH_QUORUM = ethers.utils.parseEther("25000000");
+export const CV_LOW_QUORUM = ethers.utils.parseEther("300000"); // 0.3% of initial supply
+// Default Quorum = 1.5% of initial supply
+export const CV_MEDIUM_QUORUM = ethers.utils.parseEther("3000000"); // 3% of initial supply
+export const CV_HIGH_QUORUM = ethers.utils.parseEther("6000000"); // 6% of initial supply
+export const CV_VERY_HIGH_QUORUM = ethers.utils.parseEther("25000000"); // 25% of initial supply
 
 // ArcadeGSCCoreVoting
-export const GSC_MEDIUM_QUORUM = "6";
-export const GSC_HIGH_QUORUM = "12";
+// Default Quorum = 3 votes
+export const GSC_MEDIUM_QUORUM = "6"; // 6 GSC votes
+export const GSC_HIGH_QUORUM = "12"; // 12 GSC votes
 
 ////////////////////////////
 ////// Custom Quorums //////
@@ -112,6 +115,9 @@ export const SET_ALLOWED_VERIFIERS_QUORUM = CV_HIGH_QUORUM;
 // OriginationController - setAllowedPayableCurrencies
 export const SET_ALLOWED_PAYABLE_CURRENCIES = "0x6db75724";
 export const SET_ALLOWED_PAYABLE_CURRENCIES_QUORUM = CV_HIGH_QUORUM;
+// OriginationController - setAllowedCollateralAddresses
+export const SET_ALLOWED_COLLATERAL_ADDRESSES = "0x687f27e6";
+export const SET_ALLOWED_COLLATERAL_ADDRESSES_QUORUM = CV_LOW_QUORUM;
 // OriginationController - grantRole
 export const OC_GRANT_ROLE_QUORUM = CV_HIGH_QUORUM;
 // OriginationController - revokeRole

--- a/scripts/deploy/set-custom-quorums.ts
+++ b/scripts/deploy/set-custom-quorums.ts
@@ -33,6 +33,8 @@ import {
     REVOKE_ROLE,
     SET_AIRDROP_CONTRACT,
     SET_AIRDROP_CONTRACT_QUORUM,
+    SET_ALLOWED_COLLATERAL_ADDRESSES,
+    SET_ALLOWED_COLLATERAL_ADDRESSES_QUORUM,
     SET_ALLOWED_PAYABLE_CURRENCIES,
     SET_ALLOWED_PAYABLE_CURRENCIES_QUORUM,
     SET_ALLOWED_VERIFIERS,
@@ -169,31 +171,37 @@ export async function setCustomQuorums(resources: DeployedResources) {
         SET_ALLOWED_PAYABLE_CURRENCIES_QUORUM,
     );
     await tx23.wait();
-    const tx24 = await arcadeCoreVoting.setCustomQuorum(ORIGINATION_CONTROLLER_ADDR, GRANT_ROLE, OC_GRANT_ROLE_QUORUM);
+    const tx24 = await arcadeCoreVoting.setCustomQuorum(
+        ORIGINATION_CONTROLLER_ADDR,
+        SET_ALLOWED_COLLATERAL_ADDRESSES,
+        SET_ALLOWED_COLLATERAL_ADDRESSES_QUORUM,
+    );
     await tx24.wait();
-    const tx25 = await arcadeCoreVoting.setCustomQuorum(
+    const tx25 = await arcadeCoreVoting.setCustomQuorum(ORIGINATION_CONTROLLER_ADDR, GRANT_ROLE, OC_GRANT_ROLE_QUORUM);
+    await tx25.wait();
+    const tx26 = await arcadeCoreVoting.setCustomQuorum(
         ORIGINATION_CONTROLLER_ADDR,
         REVOKE_ROLE,
         OC_REVOKE_ROLE_QUORUM,
     );
-    await tx25.wait();
-    const tx26 = await arcadeCoreVoting.setCustomQuorum(
+    await tx26.wait();
+    const tx27 = await arcadeCoreVoting.setCustomQuorum(
         ORIGINATION_CONTROLLER_ADDR,
         RENOUNCE_ROLE,
         OC_RENOUNCE_ROLE_QUORUM,
     );
-    await tx26.wait();
+    await tx27.wait();
 
     console.log(SUBSECTION_SEPARATOR);
 
     // ============= ArcadeGSCCoreVoting =============
     console.log("Setting custom quorum thresholds in ArcadeGSCCoreVoting...");
     // V3 LoanCore
-    const tx27 = await arcadeGSCCoreVoting.setCustomQuorum(LOAN_CORE_ADDR, SHUTDOWN, SHUTDOWN_QUORUM);
-    await tx27.wait();
-    // timelock
-    const tx28 = await arcadeGSCCoreVoting.setCustomQuorum(timelock.address, INCREASE_TIME, INCREASE_TIME_QUORUM);
+    const tx28 = await arcadeGSCCoreVoting.setCustomQuorum(LOAN_CORE_ADDR, SHUTDOWN, SHUTDOWN_QUORUM);
     await tx28.wait();
+    // timelock
+    const tx29 = await arcadeGSCCoreVoting.setCustomQuorum(timelock.address, INCREASE_TIME, INCREASE_TIME_QUORUM);
+    await tx29.wait();
 
     console.log(SECTION_SEPARATOR);
     console.log("✅ All custom quorums have been set.");

--- a/scripts/deploy/test/e2e.ts
+++ b/scripts/deploy/test/e2e.ts
@@ -53,6 +53,8 @@ import {
     REVOKE_ROLE,
     SET_AIRDROP_CONTRACT,
     SET_AIRDROP_CONTRACT_QUORUM,
+    SET_ALLOWED_COLLATERAL_ADDRESSES,
+    SET_ALLOWED_COLLATERAL_ADDRESSES_QUORUM,
     SET_ALLOWED_PAYABLE_CURRENCIES,
     SET_ALLOWED_PAYABLE_CURRENCIES_QUORUM,
     SET_ALLOWED_VERIFIERS,
@@ -390,6 +392,9 @@ describe("Governance Deployment", function () {
         );
         expect(await arcadeCoreVoting.quorums(ORIGINATION_CONTROLLER_ADDR, SET_ALLOWED_PAYABLE_CURRENCIES)).to.equal(
             SET_ALLOWED_PAYABLE_CURRENCIES_QUORUM,
+        );
+        expect(await arcadeCoreVoting.quorums(ORIGINATION_CONTROLLER_ADDR, SET_ALLOWED_COLLATERAL_ADDRESSES)).to.equal(
+            SET_ALLOWED_COLLATERAL_ADDRESSES_QUORUM,
         );
         expect(await arcadeCoreVoting.quorums(ORIGINATION_CONTROLLER_ADDR, GRANT_ROLE)).to.equal(OC_GRANT_ROLE_QUORUM);
         expect(await arcadeCoreVoting.quorums(ORIGINATION_CONTROLLER_ADDR, REVOKE_ROLE)).to.equal(


### PR DESCRIPTION
A low custom quorum has been added to the `custom-quorum-params` file and is used in the `set-custom-quorums` setup script. This low quorum is only used when new collateral addresses need to be added to the lending protocol's Origination Controller contract.

The main reasoning behind this is to reduce the amount of governance participation needed to whitelist new collateral to be used by the core lending protocol. Instead of requiring 1.5% (default quorum) of voting power to whitelist new collateral, now only 0.3% is required. This type of proposal will be one of the most common proposals in DAO governance and 99% of the time it should be a low friction vote.